### PR TITLE
Bump flatpak pkg version to 4.6.1

### DIFF
--- a/com.flashforge.FlashPrint.metainfo.xml
+++ b/com.flashforge.FlashPrint.metainfo.xml
@@ -36,7 +36,7 @@
   <icon type="remote" width="416" height="416">http://raw.githubusercontent.com/flathub/com.flashforge.FlashPrint/master/icon.png</icon>
   <content_rating type="oars-1.1" />
   <releases>
-    <release date="2020-12-25" version="4.6.0"/>
+    <release date="2021-01-30" version="4.6.1"/>
     <release date="2020-08-25" version="4.4.0"/>
     <release date="2019-11-09" version="4.1.0"/>
   </releases>


### PR DESCRIPTION
Complete the update to 4.6.1 done in https://github.com/flathub/com.flashforge.FlashPrint/pull/10

@bilelmoussaoui as you requested ;)