### PR TITLE
Add access to remote shares with gvfs

### DIFF
--- a/com.flashforge.FlashPrint.json
+++ b/com.flashforge.FlashPrint.json
@@ -9,6 +9,7 @@
     ],
     "finish-args": [
         "--filesystem=home",
+        "--filesystem=xdg-run/gvfs",
         "--socket=x11",
         "--device=all",
         "--share=network",


### PR DESCRIPTION
This makes it possible to drag'n'drop files from gvfs remote shares into
FlashPrint without getting an error.

See https://docs.flatpak.org/en/latest/sandbox-permissions.html#gvfs-access