### PR TITLE
Also handle application/vnd.ms-3mfdocument

### DIFF
--- a/com.flashforge.FlashPrint.desktop
+++ b/com.flashforge.FlashPrint.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=FlashPrint
-MimeType=model/stl;text/x-gcode-gx;application/x-flashprint-project;model/3mf;
+MimeType=model/stl;text/x-gcode-gx;application/x-flashprint-project;model/3mf;application/vnd.ms-3mfdocument;
 Exec=FlashPrint %F
 Icon=com.flashforge.FlashPrint
 Type=Application


### PR DESCRIPTION
As Cura and PrusaSlicer exported their own version of the mime-type with
the old name, and without any aliases.

See https://github.com/flathub/com.ultimaker.cura/issues/2 and
https://github.com/flathub/com.prusa3d.PrusaSlicer/issues/45