### PR TITLE
Revert "Update flashprint.deb to 5.4.0"

### DIFF
--- a/com.flashforge.FlashPrint.json
+++ b/com.flashforge.FlashPrint.json
@@ -58,9 +58,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "http://www.ishare3d.com/3dapp/public/FlashPrint-5/FlashPrint/flashprint5_5.4.0_amd64.deb",
-                    "sha256": "eb351ad651aa3a75ab6b5a3a3ae1207fbe7cb3f3a24d55f784a78d7cf8e9089f",
-                    "size": 11046192,
+                    "url": "http://www.ishare3d.com/3dapp/public/FlashPrint-5/FlashPrint/flashprint5_5.3.4_amd64.deb",
+                    "sha256": "f65f0fe3cd1148f2b900a3e729d2787cc1a7844423bf38e20d0362370db697b7",
+                    "size": 10964258,
                     "x-checker-data": {
                         "type": "html",
                         "url": "http://www.ishare3d.com/3dapp/public/FlashPrint-5/appInfo1",

--- a/com.flashforge.FlashPrint.metainfo.xml
+++ b/com.flashforge.FlashPrint.metainfo.xml
@@ -36,20 +36,6 @@
   <icon type="remote" width="416" height="416">http://raw.githubusercontent.com/flathub/com.flashforge.FlashPrint/master/icon.png</icon>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="5.4.0" date="2022-07-15">
-      <description>
-        <ul>
-          <li>Support setting the font size</li>
-          <li>Support setting the color theme</li>
-          <li>Support manual designation of the extruder for printing partial support in the support interface</li>
-          <li>Support viewing the text content of Gcode during slicing preview</li>
-          <li>Support drawing a translucent nozzle during slicing preview, making it convenient for viewing the current path location</li>
-          <li>The customized material slicing configuration supports setting the material name and material density (for weight estimation)</li>
-          <li>Add the function of model gallery</li>
-          <li>Other function optimization and bug modification</li>
-        </ul>
-      </description>
-    </release>
     <release version="5.3.4" date="2022-06-02">
       <description>
         <ul>


### PR DESCRIPTION
This reverts commit 070a991eaa2519bf93cc08e0ee577d84567f00c9.

As per:
https://twitter.com/ff3dprinters/status/1549655162678939648