### PR TITLE
Update runtime to 5.15-23.08

### DIFF
--- a/com.flashforge.FlashPrint.json
+++ b/com.flashforge.FlashPrint.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.flashforge.FlashPrint",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-22.08",
+    "runtime-version": "5.15-23.08",
     "sdk": "org.kde.Sdk",
     "command": "FlashPrint",
     "tags": [
@@ -40,6 +40,7 @@
             "build-commands": [
                 "install -D flashprint.sh /app/bin/FlashPrint",
                 "install -D /usr/bin/ar /app/bin/ar",
+                "install -t /app/lib /usr/lib/x86_64-linux-gnu/libsframe.so.1",
                 "install -D /usr/bin/desktop-file-install /app/bin/desktop-file-install",
                 "mkdir -p /app/lib",
                 "ARCH_TRIPLE=$(gcc --print-multiarch) && cp /usr/lib/${ARCH_TRIPLE}/libbfd-*.so /app/lib",


### PR DESCRIPTION
```
Info: runtime org.kde.Platform branch 5.15-22.08 is end-of-life, with reason:
   We strongly recommend moving to the latest Qt 5.15-based stable version of the Platform and SDK
Info: applications using this runtime:
   com.flashforge.FlashPrint
```

Also make sure to include libsframe as explained in:
https://github.com/endlessm/eos-google-chrome-app/pull/216

```
ar: error while loading shared libraries: libsframe.so.1: cannot open shared object file: No such file or directory
```
